### PR TITLE
Fix GitHub spelling

### DIFF
--- a/.make/common.mk
+++ b/.make/common.mk
@@ -45,7 +45,7 @@ install-releaser: ## Install the GoReleaser application
 	@echo "installing GoReleaser..."
 	@curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
 
-release:: ## Full production release (creates release in Github)
+release:: ## Full production release (creates release in GitHub)
 	@echo "releasing..."
 	@test $(github_token)
 	@export GITHUB_TOKEN=$(github_token) && goreleaser --rm-dist

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ help                 Show this help message
 install              Install the application
 install-go           Install the application (Using Native Go)
 lint                 Run the golangci-lint application (install if not found)
-release              Full production release (creates release in Github)
+release              Full production release (creates release in GitHub)
 release              Runs common.release then runs godocs
 release-snap         Test the full release (build binaries)
 release-test         Full production test release (everything except deploy)


### PR DESCRIPTION
## Summary
- correct `GitHub` spelling in README command list
- correct `GitHub` spelling in makefile release description

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683f3ba832348321b8b45186b1b753be