### PR TITLE
Fix comments for ISO 3166-1 alpha-2 in example

### DIFF
--- a/examples/examples.go
+++ b/examples/examples.go
@@ -9,11 +9,11 @@ import (
 
 func main() {
 
-	// Get by name (show ISO 3166-2)
+	// Get by name (show ISO 3166-1 alpha-2)
 	country := countries.GetByName("United States of America")
 	log.Println("Found: " + country.Alpha2)
 
-	// Get by ISO 3166-2  (show name)
+	// Get by ISO 3166-1 alpha-2 (show name)
 	country = countries.GetByAlpha2("US")
 	log.Println("Found: " + country.Name)
 }


### PR DESCRIPTION
## Summary
- update example comments to reference ISO 3166-1 alpha-2 codes

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683f3bb344648321803ed23130bb4cf2