### PR TITLE
fix: parallel and benchmark constant

### DIFF
--- a/countries_test.go
+++ b/countries_test.go
@@ -17,6 +17,7 @@ const (
 
 // TestCountries will test our preloaded countries
 func TestCountries(t *testing.T) {
+	t.Parallel()
 
 	// Make sure all countries are there
 	assert.NotNil(t, countries)
@@ -193,7 +194,7 @@ func ExampleGetByAlpha3() {
 // BenchmarkGetByAlpha3 benchmarks the method GetByAlpha3()
 func BenchmarkGetByAlpha3(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_ = GetByAlpha3(testCountryAlpha2)
+		_ = GetByAlpha3(testCountryAlpha3)
 	}
 }
 


### PR DESCRIPTION
## Summary
- enable parallel execution for TestCountries
- benchmark GetByAlpha3 using the correct constant

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683f3bb8193083218f38df59b70add3f