### PR TITLE
Add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md
+
+## Purpose
+
+This file defines the coding conventions, contribution workflows, and repository structure guidelines for AI agents collaborating on the codebase. It is designed to assist AI assistants (e.g., Codex, Claude, Cursor, Sweep AI) in understanding our practices, contributing safe and idiomatic code, and navigating the project effectively.
+
+AI agents must adhere to the instructions herein when reading, writing, testing, or committing code.
+
+---
+
+## 🔍 Project Overview
+
+`go-countries` is a Go library that provides a complete list of ISO-3166 countries and related metadata. It ships functions for retrieving countries by name or code and includes a generator that builds the country data from JSON. The project emphasizes simplicity and reliability and is continuously validated by linting and automated tests.
+
+* Country data lives under `data/` and is transformed into Go structs by running `go generate ./generate/...`.
+* The core package lives in the repository root (`countries.go`, `countries_data.go`).
+* Examples and tests accompany the source to demonstrate usage and maintain correctness.
+
+---
+
+## 📁 Directory Structure
+
+| Directory   | Description
+| ----------- | ------------------------------------------------------------------------
+| `data/`     | Raw JSON datasets used for code generation
+| `generate/` | Code generation utility that produces `countries_data.go`
+| `examples/` | Example program demonstrating package usage
+| `.github/`  | Issue templates, workflows, and community documentation
+| `.make/`    | Shared Makefile targets used by `Makefile`
+| `.` (root)  | Source files, tests, and generated code for the `countries` package
+
+---
+
+## 🪨 Contribution Workflow
+
+1. Format code with `go fmt` and ensure `golangci-lint` passes. Use `make lint` if unsure.
+2. Run `make test` (or `make test-ci`) before committing to execute vet, lint, and tests.
+3. Do **not** manually edit `countries_data.go`; run `go generate ./generate/...` if the data needs updating.
+4. Add or update unit tests for any new functionality or bug fix.
+5. Commit messages should be concise yet descriptive.
+6. When opening a pull request, assign it to **mrz1836**.
+
+---
+


### PR DESCRIPTION
## Summary
- add AGENTS.md with guidance for AI agents

## Testing
- `make test-short`

------
https://chatgpt.com/codex/tasks/task_e_683f4df6167c8321addd7d747a96b3d3