### PR TITLE
[Test] Update assertions and naming

### DIFF
--- a/countries_test.go
+++ b/countries_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -15,17 +16,16 @@ const (
 	testCountryISO    = "ISO 3166-2:US"
 )
 
-// TestCountries will test our preloaded countries
-func TestCountries(t *testing.T) {
-	t.Parallel()
+// TestCountries_Loaded tests that the country data is preloaded
+func TestCountries_Loaded(t *testing.T) {
 
 	// Make sure all countries are there
-	assert.NotNil(t, countries)
+	require.NotNil(t, countries)
 	assert.Len(t, countries, 249)
 
 	// Spot check a country
 	usa := GetByAlpha2(testCountryAlpha2)
-	assert.NotNil(t, usa)
+	require.NotNil(t, usa)
 
 	// All fields (USA only)
 	assert.Equal(t, testCountryAlpha2, usa.Alpha2)
@@ -44,37 +44,36 @@ func TestCountries(t *testing.T) {
 	assert.Equal(t, "021", usa.SubRegionCode)
 }
 
-// TestGetByName will test the method GetByName()
-func TestGetByName(t *testing.T) {
-	t.Parallel()
+// TestGetByName_VariousFormats tests GetByName with different input cases
+func TestGetByName_VariousFormats(t *testing.T) {
 
 	t.Run("Lower to capital", func(t *testing.T) {
 		country := GetByName(testCountry)
-		assert.NotNil(t, country)
+		require.NotNil(t, country)
 		assert.Equal(t, "United States of America", country.Name)
 	})
 
 	t.Run("Format to lower, mixed caps", func(t *testing.T) {
 		country := GetByName("AfghanistaN")
-		assert.NotNil(t, country)
+		require.NotNil(t, country)
 		assert.Equal(t, "Afghanistan", country.Name)
 	})
 
 	t.Run("Symbol detection", func(t *testing.T) {
 		country := GetByName("Åland Islands")
-		assert.NotNil(t, country)
+		require.NotNil(t, country)
 		assert.Equal(t, "Åland Islands", country.Name)
 	})
 
 	t.Run("All caps", func(t *testing.T) {
 		country := GetByName("ALBANIA")
-		assert.NotNil(t, country)
+		require.NotNil(t, country)
 		assert.Equal(t, "Albania", country.Name)
 	})
 
 	t.Run("no country found", func(t *testing.T) {
 		country := GetByName("no-country")
-		assert.Nil(t, country)
+		require.Nil(t, country)
 	})
 }
 
@@ -103,33 +102,32 @@ func BenchmarkGetByName(b *testing.B) {
 }
 
 // TestGetByAlpha2 will test the method GetByAlpha2()
-func TestGetByAlpha2(t *testing.T) {
-	t.Parallel()
+func TestGetByAlpha2_VariousFormats(t *testing.T) {
 
 	t.Run("All caps", func(t *testing.T) {
 		country := GetByAlpha2("AF")
-		assert.NotNil(t, country)
+		require.NotNil(t, country)
 		assert.Equal(t, "AF", country.Alpha2)
 	})
 
 	t.Run("Lowercase", func(t *testing.T) {
 		country := GetByAlpha2("ax")
-		assert.NotNil(t, country)
+		require.NotNil(t, country)
 		assert.Equal(t, "AX", country.Alpha2)
 	})
 
 	t.Run("Valid case", func(t *testing.T) {
 		country := GetByAlpha2(testCountryAlpha2)
-		assert.NotNil(t, country)
+		require.NotNil(t, country)
 		assert.Equal(t, testCountryAlpha2, country.Alpha2)
 	})
 
 	t.Run("Invalid country", func(t *testing.T) {
 		country := GetByAlpha2("NANA")
-		assert.Nil(t, country)
+		require.Nil(t, country)
 
 		country = GetByAlpha2("N")
-		assert.Nil(t, country)
+		require.Nil(t, country)
 	})
 }
 
@@ -151,33 +149,32 @@ func BenchmarkGetByAlpha2(b *testing.B) {
 }
 
 // TestGetByAlpha3 will test the method GetByAlpha3()
-func TestGetByAlpha3(t *testing.T) {
-	t.Parallel()
+func TestGetByAlpha3_VariousFormats(t *testing.T) {
 
 	t.Run("All caps", func(t *testing.T) {
 		country := GetByAlpha3("AFG")
-		assert.NotNil(t, country)
+		require.NotNil(t, country)
 		assert.Equal(t, "AFG", country.Alpha3)
 	})
 
 	t.Run("Lowercase", func(t *testing.T) {
 		country := GetByAlpha3("ala")
-		assert.NotNil(t, country)
+		require.NotNil(t, country)
 		assert.Equal(t, "ALA", country.Alpha3)
 	})
 
 	t.Run("Valid case", func(t *testing.T) {
 		country := GetByAlpha3(testCountryAlpha3)
-		assert.NotNil(t, country)
+		require.NotNil(t, country)
 		assert.Equal(t, testCountryAlpha3, country.Alpha3)
 	})
 
 	t.Run("Invalid country", func(t *testing.T) {
 		country := GetByAlpha3("NANA")
-		assert.Nil(t, country)
+		require.Nil(t, country)
 
 		country = GetByAlpha3("N")
-		assert.Nil(t, country)
+		require.Nil(t, country)
 	})
 }
 
@@ -199,25 +196,24 @@ func BenchmarkGetByAlpha3(b *testing.B) {
 }
 
 // TestGetByCountryCode will test the method GetByCountryCode()
-func TestGetByCountryCode(t *testing.T) {
-	t.Parallel()
+func TestGetByCountryCode_ValidInvalid(t *testing.T) {
 
 	t.Run("Valid codes", func(t *testing.T) {
 		country := GetByCountryCode(testCountryCode)
-		assert.NotNil(t, country)
+		require.NotNil(t, country)
 		assert.Equal(t, testCountryCode, country.CountryCode)
 
 		country = GetByCountryCode("248")
-		assert.NotNil(t, country)
+		require.NotNil(t, country)
 		assert.Equal(t, "248", country.CountryCode)
 	})
 
 	t.Run("Invalid codes", func(t *testing.T) {
 		country := GetByCountryCode("0")
-		assert.Nil(t, country)
+		require.Nil(t, country)
 
 		country = GetByCountryCode("12345")
-		assert.Nil(t, country)
+		require.Nil(t, country)
 	})
 }
 
@@ -239,21 +235,20 @@ func BenchmarkGetByCountryCode(b *testing.B) {
 }
 
 // TestGetByISO31662 will test the method GetByISO31662()
-func TestGetByISO31662(t *testing.T) {
-	t.Parallel()
+func TestGetByISO31662_ValidInvalid(t *testing.T) {
 
 	t.Run("Valid codes", func(t *testing.T) {
 		country := GetByISO31662(testCountryISO)
-		assert.NotNil(t, country)
+		require.NotNil(t, country)
 		assert.Equal(t, testCountryISO, country.ISO31662)
 	})
 
 	t.Run("Invalid codes", func(t *testing.T) {
 		country := GetByISO31662("0")
-		assert.Nil(t, country)
+		require.Nil(t, country)
 
 		country = GetByISO31662("12345")
-		assert.Nil(t, country)
+		require.Nil(t, country)
 	})
 }
 
@@ -275,12 +270,11 @@ func BenchmarkGetByISO31662(b *testing.B) {
 }
 
 // TestGetAll will test the method GetAll()
-func TestGetAll(t *testing.T) {
-	t.Parallel()
+func TestGetAll_Basic(t *testing.T) {
 
 	t.Run("valid countries", func(t *testing.T) {
 		c := GetAll()
-		assert.NotNil(t, c)
+		require.NotNil(t, c)
 		assert.Len(t, c, 249)
 	})
 }


### PR DESCRIPTION
## What Changed
- swapped `assert.Nil/NotNil` with `require` variants
- removed `t.Parallel()` calls
- renamed tests to follow `TestFunctionName_ScenarioDescription`
- added `require` import

## Why It Was Needed
- align tests with repository standards for assertion style and naming

## Testing Performed
- `go fmt ./...`
- `goimports -w $(git ls-files '*.go')`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- low; tests only

------
https://chatgpt.com/codex/tasks/task_e_683f8320f2288321b116224ed3b56024