### PR TITLE
[Countries] Return copy from GetAll

### DIFF
--- a/countries.go
+++ b/countries.go
@@ -110,10 +110,11 @@ func GetByISO31662(iso string) *Country {
 	return nil
 }
 
-// GetAll will return all the countries in the list.
-// It returns a CountryList, which is a slice of pointers to Country structs.
-// This method is useful for retrieving the entire dataset of countries
-// and can be used for operations that require access to all country information.
+// GetAll returns a copy of all countries in the list.
+// The returned slice has its own backing array so callers can modify the slice
+// without affecting the package data. The country structs themselves are not
+// copied.
 func GetAll() CountryList {
-	return countries
+	clone := append(CountryList(nil), countries...)
+	return clone
 }

--- a/countries_test.go
+++ b/countries_test.go
@@ -286,18 +286,20 @@ func TestGetAll(t *testing.T) {
 	})
 
 	t.Run("returns a copy", func(t *testing.T) {
-		c := GetAll()
-		require.NotNil(t, c)
+		c1 := GetAll()
+		require.NotNil(t, c1)
 
-		original := countries[0]
-		c[0] = &Country{Alpha2: "XX"}
+		c2 := GetAll()
+		require.NotNil(t, c2)
 
-		assert.Same(t, original, countries[0])
-		assert.NotSame(t, original, c[0])
+		// Modify the first slice
+		c1[0] = &Country{Alpha2: "XX"}
+		c1 = append(c1, &Country{Alpha2: "YY"})
 
-		c = append(c, &Country{Alpha2: "YY"})
-		assert.Len(t, c, 250)
-		assert.Len(t, countries, 249)
+		// Verify the second slice remains unchanged
+		assert.NotSame(t, c1[0], c2[0])
+		assert.Len(t, c1, 250)
+		assert.Len(t, c2, 249)
 	})
 }
 

--- a/countries_test.go
+++ b/countries_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -280,8 +281,23 @@ func TestGetAll(t *testing.T) {
 
 	t.Run("valid countries", func(t *testing.T) {
 		c := GetAll()
-		assert.NotNil(t, c)
+		require.NotNil(t, c)
 		assert.Len(t, c, 249)
+	})
+
+	t.Run("returns a copy", func(t *testing.T) {
+		c := GetAll()
+		require.NotNil(t, c)
+
+		original := countries[0]
+		c[0] = &Country{Alpha2: "XX"}
+
+		assert.Same(t, original, countries[0])
+		assert.NotSame(t, original, c[0])
+
+		c = append(c, &Country{Alpha2: "YY"})
+		assert.Len(t, c, 250)
+		assert.Len(t, countries, 249)
 	})
 }
 


### PR DESCRIPTION
## Summary
- return a cloned slice from `GetAll`
- ensure `GetAll` returns a copy in unit tests

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683f832f46f483219217ad4f8962e439