### PR TITLE
[Docs] Add support guidelines

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,21 @@
+# Support Guidelines
+
+This document explains how to get help with **go-countries**.
+
+## Questions and Discussion
+- Search existing [discussions](https://github.com/mrz1836/go-countries/discussions) for similar topics.
+- If you cannot find an answer, start a new discussion.
+
+## Reporting Issues
+- Look through the [issue tracker](https://github.com/mrz1836/go-countries/issues) for existing bugs.
+- Open a new issue if your problem has not been reported and provide steps to reproduce.
+
+## Security Vulnerabilities
+- For potential security issues, do **not** open a public issue.
+- Follow the steps in our [security policy](SECURITY.md) instead.
+
+## Direct Contact
+For private inquiries, reach the maintainers at [mrz1818@pm.me](mailto:mrz1818@pm.me).
+
+We appreciate your interest and will do our best to assist you.
+


### PR DESCRIPTION
Fixes #

## What Changed
- Added `.github/SUPPORT.md` with instructions on how users can get assistance

## Why It Was Needed
- GitHub's community profile recommends a SUPPORT document to clarify where users should ask questions or report issues

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- Documentation only. No runtime impact.

------
https://chatgpt.com/codex/tasks/task_e_6840620639248321a7456c6186841e12