### PR TITLE
[Docs] Update security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,12 +2,34 @@
 
 ## Supported & Maintained Versions
 
-| Version | Supported          |
-| ------- | ------------------ |
+| Version | Supported |
+| ------- | --------- |
 | 1.x.x   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 
-Individuals or organizations that are experiencing a product security issue are strongly encouraged to contact the [project maintainers](mailto:mrz1818@pm.me).
-We welcome reports from independent researchers, industry organizations, vendors, customers, and other sources concerned with our project security.
-The minimal data needed for reporting a security issue is a description of the potential vulnerability.
+Please email the [project maintainers](mailto:mrz1818@pm.me) with a detailed
+report. We welcome submissions from independent researchers, industry
+organizations, vendors and customers. Include:
+
+- A description of the issue and its impact
+- Steps to reproduce or proof of concept
+- Known workarounds or mitigation
+
+Do **not** open a public issue or pull request for security matters.
+
+### Response Expectations
+
+- **Acknowledgment** within 72 hours of receipt
+- **Status updates** at least every 5 business days
+- **Resolution target** of 30 days for confirmed vulnerabilities
+
+If you prefer encrypted communication, request our PGP public key in your
+initial email. Official security correspondence will be signed with this key.
+
+### Security Tooling
+
+We use [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) to
+scan dependencies. You can run `make govulncheck` locally to check your own
+builds.
+


### PR DESCRIPTION
## What Changed
- expanded `.github/SECURITY.md` with response timeline, optional PGP usage and govulncheck link

## Why It Was Needed
- the previous policy only contained basic contact info and lacked modern disclosure guidance

## Testing Performed
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`

## Impact / Risk
- documentation only; no runtime impact

Assign: @mrz1836

------
https://chatgpt.com/codex/tasks/task_e_6840620ea7cc832193a1e407c0b7c6f4