### PR TITLE
[Repo] add editor config and git attributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig helps maintain consistent coding styles
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Enforce Unix-style line endings for all files
+* text=auto eol=lf
+
+# Go source files
+*.go text
+*.mod text
+*.sum text
+
+# Treat binary files appropriately
+*.png binary
+*.jpg binary
+*.gif binary
+*.svg text


### PR DESCRIPTION
## What Changed
- added `.editorconfig` defining line endings, indentation and trimming rules
- added `.gitattributes` to normalize line endings and mark text/binary files

## Why It Was Needed
- repository lacked baseline settings for editors and git, which can lead to inconsistent line endings and formatting across environments

## Testing Performed
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`

## Impact / Risk
- no breaking code changes, just repository configuration files


------
https://chatgpt.com/codex/tasks/task_e_68406214abb48321a981ef1deae58aa3