### PR TITLE
[Docs] Clarify AGENTS source of truth in Cursor rules

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,30 @@
+# Cursor Rules derived from .github/AGENTS.md
+
+## Read AGENTS.md First
+All contributors must read `.github/AGENTS.md` for complete guidelines. If any rule here conflicts with that file, **AGENTS.md** takes precedence.
+
+## Coding Standards
+- Format with `go fmt ./...` and `goimports -w .`.
+- Lint with `golangci-lint run` and vet with `go vet ./...`.
+- Run `go test ./...` before committing.
+- Follow Go naming and commenting conventions described in AGENTS.md.
+
+## Commit Messages
+- Use the format `<type>(<scope>): <imperative short description>`.
+- Types include `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `build`, `ci`.
+
+## Pull Requests
+- Title format: `[Subsystem] Imperative and concise summary of change`.
+- Description must include the sections:
+  1. **What Changed**
+  2. **Why It Was Needed**
+  3. **Testing Performed**
+  4. **Impact / Risk**
+
+## Dependency Management
+- Manage modules with `go mod tidy` after import changes.
+- Run `make govulncheck` to check for vulnerabilities when dependencies change.
+
+## Security Reporting
+- Do not open public issues for vulnerabilities.
+- Follow `SECURITY.md` for responsible disclosure.


### PR DESCRIPTION
## What Changed
- added "Read AGENTS.md First" section to `.cursorrules` referencing `.github/AGENTS.md` as the authoritative guide

## Why It Was Needed
- ensure developers know the AGENTS file is the definitive reference and resolve any contradictions

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- low; documentation clarification only

------
https://chatgpt.com/codex/tasks/task_e_68407842c2788321b9e2241326c8f09f