### PR TITLE
[CI] Add govulncheck step to run-tests workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -103,7 +103,13 @@ jobs:
         run: make test-ci          # assumes this target runs golangci-lint + tests
 
       # ————————————————————————————————————————————————————————————————
-      # 7. Upload coverage to Codecov
+      # 7. Scan for vulnerabilities with govulncheck
+      # ————————————————————————————————————————————————————————————————
+      - name: Run govulncheck
+        run: make govulncheck
+
+      # ————————————————————————————————————————————————————————————————
+      # 8. Upload coverage to Codecov
       # ————————————————————————————————————————————————————————————————
       - name: Upload code coverage
         uses: codecov/codecov-action@v5.4.3


### PR DESCRIPTION
## What Changed
- run govulncheck after vet/lint/tests in `run-tests.yml`

## Why It Was Needed
- to catch known vulnerabilities during CI

## Testing Performed
- `make test-ci`
- `make govulncheck`

## Impact / Risk
- no breaking changes; additional security scanning step only


------
https://chatgpt.com/codex/tasks/task_e_68407b3e893c8321935faed9ab434b05