### PR TITLE
[Docs] Add sweep rules

### DIFF
--- a/.github/sweep.yaml
+++ b/.github/sweep.yaml
@@ -1,0 +1,18 @@
+gha_enabled: true
+branch: master
+blocked_dirs: []
+draft: false
+description: |
+  go-countries is a Go library providing ISO-3166 country data.
+  Sweep AI must follow the repository guidelines in .github/AGENTS.md.
+rules:
+  - "Read .github/AGENTS.md first; it overrides these rules."
+  - "Format code with 'go fmt ./...' and 'goimports -w .'"
+  - "Lint with 'golangci-lint run' and vet with 'go vet ./...'"
+  - "Run 'go test ./...' before committing"
+  - "Commit messages use '<type>(<scope>): <short description>'"
+  - "PR titles use '[Subsystem] Imperative and concise summary'"
+  - "PR descriptions include: What Changed, Why It Was Needed, Testing Performed, Impact / Risk"
+  - "Run 'go mod tidy' after import changes"
+  - "Run 'make govulncheck' when dependencies change"
+  - "Report vulnerabilities privately following SECURITY.md"


### PR DESCRIPTION
## What Changed
- Added `.github/sweep.yaml` with Sweep AI rules derived from `AGENTS.md`

## Why It Was Needed
- Ensure Sweep AI follows the same guidelines as other automated contributors

## Testing Performed
- `go fmt ./...`
- `goimports -w $(git ls-files '*.go')`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- Documentation only; no impact to production code.

/assign @mrz1836

------
https://chatgpt.com/codex/tasks/task_e_68407e7ed590832195bc9f8d236857c1