### PR TITLE
Add citation update make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,13 @@ clean: ## Remove previous builds and any test cache data
 .PHONY: release
 release:: ## Runs common.release then runs godocs
 	@$(MAKE) godocs
+
+.PHONY: citation
+citation: ## Update version in CITATION.cff (citation version=X.Y.Z)
+	@echo "updating CITATION.cff version..."
+	@test $(version)
+	@if [ "$(shell uname)" = "Darwin" ]; then \
+	        sed -i '' -e 's/^version: \".*\"/version: \"$(version)\"/' CITATION.cff; \
+	else \
+	        sed -i -e 's/^version: \".*\"/version: \"$(version)\"/' CITATION.cff; \
+	fi


### PR DESCRIPTION
## What Changed
- added a `citation` make target to update the version field in `CITATION.cff`

## Why It Was Needed
- keep citation metadata in sync with new tags when releasing

## Testing Performed
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `make govulncheck`
- executed `make citation version=0.3.0` locally to confirm the file is updated

## Impact / Risk
- minimal; new optional make command does not affect existing workflows

------
https://chatgpt.com/codex/tasks/task_e_68408e4680288321a33f332fcf0a5c61