### PR TITLE
[CI] Add auto merge on approval workflow

### DIFF
--- a/.github/workflows/auto-merge-on-approval.yml
+++ b/.github/workflows/auto-merge-on-approval.yml
@@ -32,13 +32,17 @@ on:
     types: [completed]
   status: {}
 
+# Cancel older runs of the same PR if a new commit is pushed
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
   automerge:
-    concurrency: pull_request_${{ github.event.pull_request.number }}
     runs-on: ubuntu-latest
     steps:
       - name: Attempt auto-merge

--- a/.github/workflows/auto-merge-on-approval.yml
+++ b/.github/workflows/auto-merge-on-approval.yml
@@ -50,7 +50,7 @@ jobs:
             const changesRequested = reviews.filter(r => r.state === 'CHANGES_REQUESTED').length;
 
             const sha = pr.head.sha;
-            const { data: statuses } = await github.rest.repos.listCommitStatusesForRef({
+            const { data: checks } = await github.rest.checks.listForRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: sha,

--- a/.github/workflows/auto-merge-on-approval.yml
+++ b/.github/workflows/auto-merge-on-approval.yml
@@ -1,0 +1,90 @@
+# ------------------------------------------------------------------------------
+#  Auto Merge on Approval Workflow
+#
+#  Purpose   : Automatically merge PRs once all approval and CI conditions pass.
+#  Triggers  : Pull request events, review submissions, and completed checks.
+#  Maintainer: @mrz1836
+# ------------------------------------------------------------------------------
+
+name: auto-merge-on-approval
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled, edited]
+  pull_request_review:
+    types: [submitted]
+  check_suite:
+    types: [completed]
+  status: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Attempt auto-merge
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request ?? (await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            })).data;
+            const prNumber = pr.number;
+            const title = pr.title || "";
+            const labels = pr.labels.map(l => l.name);
+            const isDraft = pr.draft;
+            const requestedReviewers = pr.requested_reviewers || [];
+
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const approvals = reviews.filter(r => r.state === 'APPROVED').length;
+            const changesRequested = reviews.filter(r => r.state === 'CHANGES_REQUESTED').length;
+
+            const sha = pr.head.sha;
+            const { data: statuses } = await github.rest.repos.listCommitStatusesForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: sha,
+            });
+            const requiredChecks = [
+              'test (1.22.x, ubuntu-latest)',
+              'test (1.23.x, ubuntu-latest)',
+              'test (1.24.x, ubuntu-latest)',
+              'Analyze (go)',
+            ];
+            const checksPass = requiredChecks.every(name => {
+              const status = statuses.find(s => s.context === name);
+              return status && status.state === 'success';
+            });
+
+            const titleHasWip = /wip/i.test(title);
+            const hasWipLabel = labels.includes('work-in-progress');
+
+            if (
+              approvals >= 1 &&
+              requestedReviewers.length === 0 &&
+              changesRequested === 0 &&
+              checksPass &&
+              !titleHasWip &&
+              !hasWipLabel &&
+              !isDraft
+            ) {
+              await github.rest.pulls.merge({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                merge_method: 'merge',
+              });
+              console.log(`Pull request #${prNumber} merged.`);
+            } else {
+              console.log('Conditions not met for automerge.');
+            }

--- a/.github/workflows/auto-merge-on-approval.yml
+++ b/.github/workflows/auto-merge-on-approval.yml
@@ -9,7 +9,7 @@
 name: auto-merge-on-approval
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled, edited]
   pull_request_review:
     types: [submitted]

--- a/.github/workflows/auto-merge-on-approval.yml
+++ b/.github/workflows/auto-merge-on-approval.yml
@@ -23,6 +23,7 @@ permissions:
 
 jobs:
   automerge:
+    concurrency: pull_request_${{ github.event.pull_request.number }}
     runs-on: ubuntu-latest
     steps:
       - name: Attempt auto-merge

--- a/.github/workflows/auto-merge-on-approval.yml
+++ b/.github/workflows/auto-merge-on-approval.yml
@@ -92,6 +92,7 @@ jobs:
             const hasWipLabel = labels.includes('work-in-progress');
 
             // Wrap merge in try/catch for error handling
+            // Verbose output for unmet conditions
             if (
               approvals >= 1 &&
               requestedReviewers.length === 0 &&
@@ -113,5 +114,30 @@ jobs:
                 core.setFailed(`Failed to merge PR #${prNumber}: ${error.message}`);
               }
             } else {
-              console.log('Conditions not met for auto-merge.');
+              if (approvals < 1) {
+                console.log('Auto-merge not performed: Less than 1 approval.');
+              }
+              if (requestedReviewers.length > 0) {
+                console.log('Auto-merge not performed: There are still requested reviewers.');
+              }
+              if (changesRequested > 0) {
+                console.log('Auto-merge not performed: There are reviews with "Changes Requested".');
+              }
+              if (!checksPass) {
+                // Find which checks did not pass
+                const failedChecks = requiredChecks.filter(name => {
+                  const run = checkRuns.find(c => c.name === name);
+                  return !(run && run.conclusion === 'success');
+                });
+                console.log(`Auto-merge not performed: The following required checks did not pass: ${failedChecks.join(', ')}`);
+              }
+              if (titleHasWip) {
+                console.log('Auto-merge not performed: PR title contains "WIP".');
+              }
+              if (hasWipLabel) {
+                console.log('Auto-merge not performed: PR has the "work-in-progress" label.');
+              }
+              if (isDraft) {
+                console.log('Auto-merge not performed: PR is a draft.');
+              }
             }

--- a/.github/workflows/auto-merge-on-approval.yml
+++ b/.github/workflows/auto-merge-on-approval.yml
@@ -1,9 +1,24 @@
 # ------------------------------------------------------------------------------
 #  Auto Merge on Approval Workflow
 #
-#  Purpose   : Automatically merge PRs once all approval and CI conditions pass.
-#  Triggers  : Pull request events, review submissions, and completed checks.
+#  Purpose: Automatically merge PRs once all approval and CI conditions pass.
+#
+#  Triggers: Pull request events, review submissions, and completed checks.
+#
 #  Maintainer: @mrz1836
+#
+#  Rules for Auto-Merge:
+#    • At least 1 approval review is required.
+#    • No requested reviewers must remain.
+#    • No reviews with "Changes Requested" status.
+#    • All required status checks must pass:
+#        - test (1.22.x, ubuntu-latest)
+#        - test (1.23.x, ubuntu-latest)
+#        - test (1.24.x, ubuntu-latest)
+#        - Analyze (go)
+#    • PR title must not contain "WIP" (case-insensitive).
+#    • PR must not have the "work-in-progress" label.
+#    • PR must not be a draft.
 # ------------------------------------------------------------------------------
 
 name: auto-merge-on-approval
@@ -40,8 +55,8 @@ jobs:
             const title = pr.title || "";
             const labels = pr.labels.map(l => l.name);
             const isDraft = pr.draft;
-            const requestedReviewers = pr.requested_reviewers || [];
 
+            // Fetch reviews
             const { data: reviews } = await github.rest.pulls.listReviews({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -50,6 +65,10 @@ jobs:
             const approvals = reviews.filter(r => r.state === 'APPROVED').length;
             const changesRequested = reviews.filter(r => r.state === 'CHANGES_REQUESTED').length;
 
+            // Fetch requested reviewers
+            const requestedReviewers = pr.requested_reviewers || [];
+
+            // Fetch check runs for the latest commit
             const sha = pr.head.sha;
             const { data: checks } = await github.rest.checks.listForRef({
               owner: context.repo.owner,
@@ -62,14 +81,17 @@ jobs:
               'test (1.24.x, ubuntu-latest)',
               'Analyze (go)',
             ];
+            // Use check_runs instead of undefined statuses
+            const checkRuns = checks.check_runs || [];
             const checksPass = requiredChecks.every(name => {
-              const status = statuses.find(s => s.context === name);
-              return status && status.state === 'success';
+              const run = checkRuns.find(c => c.name === name);
+              return run && run.conclusion === 'success';
             });
 
             const titleHasWip = /wip/i.test(title);
             const hasWipLabel = labels.includes('work-in-progress');
 
+            // Wrap merge in try/catch for error handling
             if (
               approvals >= 1 &&
               requestedReviewers.length === 0 &&
@@ -79,13 +101,17 @@ jobs:
               !hasWipLabel &&
               !isDraft
             ) {
-              await github.rest.pulls.merge({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber,
-                merge_method: 'merge',
-              });
-              console.log(`Pull request #${prNumber} merged.`);
+              try {
+                await github.rest.pulls.merge({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                  merge_method: 'merge',
+                });
+                console.log(`Pull request #${prNumber} merged.`);
+              } catch (error) {
+                core.setFailed(`Failed to merge PR #${prNumber}: ${error.message}`);
+              }
             } else {
-              console.log('Conditions not met for automerge.');
+              console.log('Conditions not met for auto-merge.');
             }

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -25,6 +25,11 @@ permissions:
   contents: write
   pull-requests: write
 
+# Cancel older runs of the same PR if a new commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ------------------------------------------------------------------------------
   # Auto-merge: Dependabot PR Automation

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -21,6 +21,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+# Cancel older runs of the same PR if a new commit is pushed
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 permissions:
   pull-requests: write
   issues: write

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ vet                      Run the Go vet application
 
 | Workflow Name                                                                | Description                                                                                                            |
 |------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| [auto-merge-on-approval.yml](.github/workflows/auto-merge-on-approval.yml)   | Automatically merges PRs after approval and all required checks, following strict rules.                               |
 | [codeql-analysis.yml](.github/workflows/codeql-analysis.yml)                 | Analyzes code for security vulnerabilities using GitHub CodeQL.                                                        |
 | [dependabot-merge.yml](.github/workflows/dependabot-automerge.yml)           | Automatically merges Dependabot PRs that meet all requirements.                                                        |
 | [pull-request-management.yml](.github/workflows/pull-request-management.yml) | Labels PRs by branch prefix, assigns a default user if none is assigned, and welcomes new contributors with a comment. |


### PR DESCRIPTION
## What Changed
- added `auto-merge-on-approval` workflow to merge pull requests when approvals and CI checks succeed

## Why It Was Needed
- replicates Mergify auto‑merge rule in native GitHub Actions

## Testing Performed
- `go fmt ./...`
- `goimports -w $(git ls-files '*.go')`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- Minimal risk; new automation only merges when all required conditions are satisfied


------
https://chatgpt.com/codex/tasks/task_e_6841bf09e828832184ab20448e29fbd8