### PR TITLE
[CI] Delete merged branches after PR close

### DIFF
--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -1,0 +1,56 @@
+# ------------------------------------------------------------------------------
+#  Delete Merged Branches Workflow
+#
+#  Purpose   : Remove feature branches after a pull request has been merged.
+#
+#  Triggers  : Pull request close events.
+#
+#  Maintainer: @mrz1836
+# ------------------------------------------------------------------------------
+
+name: delete-merged-branches
+
+on:
+  pull_request:
+    types: [closed]
+
+# Cancel older runs of the same PR if a new commit is pushed
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Delete branch
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = context.payload.pull_request.head.ref;
+            const protectedBranches = ['master', 'main'];
+            if (!protectedBranches.includes(branch)) {
+              try {
+                await github.rest.git.deleteRef({
+                  owner,
+                  repo,
+                  ref: `heads/${branch}`,
+                });
+                console.log(`Deleted branch ${branch}`);
+              } catch (error) {
+                if (error.status === 422) {
+                  console.log(`Branch ${branch} already deleted or protected.`);
+                } else {
+                  core.setFailed(`Failed to delete branch ${branch}: ${error.message}`);
+                }
+              }
+            } else {
+              console.log(`Skipping deletion for protected branch ${branch}`);
+            }


### PR DESCRIPTION
## What Changed
- add workflow `delete-merged-branches.yml` to remove branches once pull requests are merged

## Why It Was Needed
- replaces Mergify rule so merged feature branches are automatically cleaned up

## Testing Performed
- `gofmt -w $(git ls-files '*.go')`
- `goimports -w $(git ls-files '*.go')`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- no breaking changes; workflow only deletes non-default branches after merge

------
https://chatgpt.com/codex/tasks/task_e_6841c727802883219fb4627f3ba675f4