### PR TITLE
[Build] Improve help target output

### DIFF
--- a/.make/common.mk
+++ b/.make/common.mk
@@ -54,7 +54,7 @@ diff: ## Show the git diff
 
 .PHONY: help
 help: ## Show this help message
-	@egrep -h '^(.+)\:\ ##\ (.+)' ${MAKEFILE_LIST} | column -t -c 2 -s ':#'
+	@grep -Eh '^(.+)\:\ ##\ (.+)' ${MAKEFILE_LIST} | sort | column -t -c 2 -s ':#'
 
 .PHONY: install-releaser
 install-releaser: ## Install the GoReleaser application


### PR DESCRIPTION
Assigning @mrz1836

## What Changed
- replaced deprecated `egrep` with `grep -E`
- sorted `make help` output alphabetically
- fixed tab indentation in `common.mk`

## Why It Was Needed
- `egrep` has been deprecated
- alphabetical help makes targets easier to locate

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- Low risk build script change


------
https://chatgpt.com/codex/tasks/task_e_6841d81d4648832181b723329604c418