### PR TITLE
[Docs] Automate README make command list

### DIFF
--- a/.make/common.mk
+++ b/.make/common.mk
@@ -54,18 +54,25 @@ diff: ## Show the git diff
 
 .PHONY: help
 help: ## Show this help message
-	@grep -Eh '^(.+)\:\ ##\ (.+)' ${MAKEFILE_LIST} | sort | column -t -c 2 -s ':#'
+	@grep -Eh '^(.+):\ ##\ (.+)' ${MAKEFILE_LIST} | sort | column -t -c 2 -s ':#'
+
+.PHONY: update-readme-make-commands
+update-readme-make-commands: ## Update README section with latest make help output
+	@echo "updating README make commands..."
+@TMP=$$(mktemp) && \
+	$(MAKE) --no-print-directory -s help | grep -v '^$$' > $$TMP && \
+	awk -v hf=$$TMP 'BEGIN{skip=0} /<!-- make-help-start -->/{print; print "```text"; while((getline line < hf)>0) print line; print "```"; skip=1; next} /<!-- make-help-end -->/{print; skip=0; next} !skip{print}' README.md > README.md.tmp && mv README.md.tmp README.md && rm $$TMP
 
 .PHONY: install-releaser
 install-releaser: ## Install the GoReleaser application
-@echo "installing GoReleaser..."
-@curl -sSfL https://install.goreleaser.com/github.com/goreleaser/goreleaser@latest | sh
+	@echo "installing GoReleaser..."
+	@curl -sSfL https://install.goreleaser.com/github.com/goreleaser/goreleaser@latest | sh
 
 .PHONY: release
 release:: ## Full production release (creates release in GitHub)
-@echo "releasing..."
-@test -n "$(github_token)"
-@export GITHUB_TOKEN=$(github_token) && goreleaser --rm-dist
+	@echo "releasing..."
+	@test -n "$(github_token)"
+	@export GITHUB_TOKEN=$(github_token) && goreleaser --rm-dist
 
 .PHONY: release-test
 release-test: ## Full production test release (everything except deploy)

--- a/README.md
+++ b/README.md
@@ -198,40 +198,42 @@ make help
 
 List of all current commands:
 
+<!-- make-help-start -->
 ```text
-all                      Runs multiple commands
-citation                 Update version in CITATION.cff (citation version=X.Y.Z)
-clean                    Remove previous builds and any test cache data
-clean-mods               Remove all the Go mod cache
-coverage                 Shows the test coverage
-diff                     Show the git diff
-generate                 Runs the go generate command in the base of the repo
-godocs                   Sync the latest tag with GoDocs
-govulncheck-install      Install govulncheck for vulnerability scanning
-help                     Show this help message
-install                  Install the application
-install-go               Install the application (Using Native Go)
-install-releaser         Install the GoReleaser application
-lint                     Run the golangci-lint application (install if not found)
-release                  Full production release (creates release in GitHub)
-release                  Runs common.release then runs godocs
-release-snap             Test the full release (build binaries)
-release-test             Full production test release (everything except deploy)
-replace-version          Replaces the version in HTML/JS (pre-deploy)
-tag                      Generate a new tag and push (tag version=0.0.0)
-tag-remove               Remove a tag if found (tag-remove version=0.0.0)
-tag-update               Update an existing tag to current commit (tag-update version=0.0.0)
-test                     Runs lint and ALL tests
-test-ci                  Runs all tests via CI (exports coverage)
-test-ci-no-race          Runs all tests via CI (no race) (exports coverage)
-test-ci-short            Runs unit tests via CI (exports coverage)
-test-no-lint             Runs just tests
-test-short               Runs vet, lint and tests (excludes integration tests)
-test-unit                Runs tests and outputs coverage
-uninstall                Uninstall the application (and remove files)
-update-linter            Update the golangci-lint package (macOS only)
-vet                      Run the Go vet application
+all                                 Runs multiple commands                                               
+citation                            Update version in CITATION.cff (citation version=X.Y.Z)              
+clean-mods                          Remove all the Go mod cache                                          
+coverage                            Shows the test coverage                                              
+diff                                Show the git diff                                                    
+generate                            Runs the go generate command in the base of the repo                 
+godocs                              Sync the latest tag with GoDocs                                      
+govulncheck-install                 Install govulncheck for vulnerability scanning                       
+help                                Show this help message                                               
+install-go                          Install the application (Using Native Go)                            
+install-releaser                    Install the GoReleaser application                                   
+install                             Install the application                                              
+lint                                Run the golangci-lint application (install if not found)             
+release-snap                        Test the full release (build binaries)                               
+release-test                        Full production test release (everything except deploy)              
+release                                                                                                   Full production release (creates release in GitHub)
+release                                                                                                   Runs common.release then runs godocs
+replace-version                     Replaces the version in HTML/JS (pre-deploy)                         
+tag-remove                          Remove a tag if found (tag-remove version=0.0.0)                     
+tag-update                          Update an existing tag to current commit (tag-update version=0.0.0)  
+tag                                 Generate a new tag and push (tag version=0.0.0)                      
+test-ci-no-race                     Runs all tests via CI (no race) (exports coverage)                   
+test-ci-short                       Runs unit tests via CI (exports coverage)                            
+test-ci                             Runs all tests via CI (exports coverage)                             
+test-no-lint                        Runs just tests                                                      
+test-short                          Runs vet, lint and tests (excludes integration tests)                
+test-unit                           Runs tests and outputs coverage                                      
+test                                Runs lint and ALL tests                                              
+uninstall                           Uninstall the application (and remove files)                         
+update-linter                       Update the golangci-lint package (macOS only)                        
+update-readme-make-commands         Update README section with latest make help output                   
+vet                                 Run the Go vet application                                           
 ```
+<!-- make-help-end -->
 
 </details>
 


### PR DESCRIPTION
## What Changed
- added `update-readme-make-commands` target in `common.mk`
- inserted markers in `README.md` and automated update logic
- fixed tab characters for some targets in `common.mk`

## Why It Was Needed
The list of make commands in the README could fall out of sync with the actual help output. A new make target now refreshes this section automatically.

## Testing Performed
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`

## Impact / Risk
- Minimal; updates documentation and makefile tooling without affecting library code.


------
https://chatgpt.com/codex/tasks/task_e_6841db33be488321ae32f350d2ff6b7d