### PR TITLE
[countries] Add tests for capital correctness

### DIFF
--- a/countries_test.go
+++ b/countries_test.go
@@ -902,3 +902,27 @@ func TestAlphaCodes_Constants(t *testing.T) {
 	assert.Equal(t, Alpha3ZMB, "ZMB")
 	assert.Equal(t, Alpha3ZWE, "ZWE")
 }
+
+func TestCountryCapitals_Correctness(t *testing.T) {
+	tests := []struct {
+		name        string
+		countryName string
+		expected    string
+	}{
+		{name: "Afghanistan", countryName: "Afghanistan", expected: "Kabul"},
+		{name: "Australia", countryName: "Australia", expected: "Canberra"},
+		{name: "Brazil", countryName: "Brazil", expected: "Brasília"},
+		{name: "Canada", countryName: "Canada", expected: "Ottawa"},
+		{name: "France", countryName: "France", expected: "Paris"},
+		{name: "Japan", countryName: "Japan", expected: "Tokyo"},
+		{name: "United Kingdom", countryName: "United Kingdom of Great Britain and Northern Ireland", expected: "London"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			country := GetByName(tt.countryName)
+			require.NotNil(t, country)
+			assert.Equal(t, tt.expected, country.Capital)
+		})
+	}
+}


### PR DESCRIPTION
## What Changed
- add table-driven test verifying capitals for several countries

## Why It Was Needed
- ensures country metadata contains expected capitals, preventing regressions

## Testing Performed
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- no breaking changes
- minimal risk, added tests only

Assign: @mrz1836

------
https://chatgpt.com/codex/tasks/task_e_6845c1409b148321ae662b5d761c4e8e