### PR TITLE
[CI] Remove reviewers from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       interval: "weekly"
       # Check for npm updates at 9am UTC (5am EST)
       time: "10:00"
-    reviewers:
-      - "mrz1836"
     assignees:
       - "mrz1836"
     # Labels must be created first
@@ -24,8 +22,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    reviewers:
-      - "mrz1836"
     assignees:
       - "mrz1836"
     labels:


### PR DESCRIPTION
## What Changed
- removed `reviewers` field from `.github/dependabot.yml`
- ensured file ends with newline

## Why It Was Needed
- GitHub is deprecating Dependabot reviewers in favor of CODEOWNERS on May 20, 2025
- removing the option prevents configuration errors going forward

## Testing Performed
- `gofmt -w .`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `make govulncheck`

## Impact / Risk
- Low. Configuration change only; Dependabot will continue to open PRs without specifying reviewers.


------
https://chatgpt.com/codex/tasks/task_e_68482eb76e7083218fdf08b9cd849ae9