### PR TITLE
[Countries] Add fuzz test for GetByAlpha2

### DIFF
--- a/countries_fuzz_test.go
+++ b/countries_fuzz_test.go
@@ -1,0 +1,26 @@
+package countries
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// FuzzGetByAlpha2 checks that GetByAlpha2 correctly handles
+// alpha-2 codes with varying cases and returns a valid Country
+// when the input represents a known code.
+func FuzzGetByAlpha2(f *testing.F) {
+	seed := []string{"us", "GB", "Ca", "zz", ""}
+	for _, s := range seed {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, code string) {
+		c := GetByAlpha2(code)
+		if c == nil {
+			return
+		}
+		require.Len(t, c.Alpha2, 2)
+		require.Equal(t, strings.ToUpper(code), c.Alpha2)
+	})
+}


### PR DESCRIPTION
## What Changed
- Added `countries_fuzz_test.go` implementing `FuzzGetByAlpha2`

## Why It Was Necessary
- Increase test coverage and exercise case handling for `GetByAlpha2`

## Testing Performed
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- Low; tests only

------
https://chatgpt.com/codex/tasks/task_e_685475b105b88321bfab86077e74739e